### PR TITLE
Fix typos and hide blank `Usage Examples` from nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 You, yes you, can contribute fixes and add content to the BarRaider Knowledgebase.  If you are experienced with Git and Github, feel free to fork the repository and submit a pull request with your contributions.  Otherwise, head over to the [Bar Raiders Discord](http://discord.barraider.com) to provide your feedback.  Please understand that this may take longer, as someone else will need to understand, and then implement, your changes.
 
 **Trusted Contributors**
-Trusted Contributors and BarRaider Moderators are invited to submit changes without approval.  If you are given this access, you may accept your own Pull Requests. Please do not commit unfinished work to `main` as this will be immediatley deployed to the KB.  
+Trusted Contributors and BarRaider Moderators are invited to submit changes without approval.  If you are given this access, you may accept your own Pull Requests. Please do not commit unfinished work to `main` as this will be immediately deployed to the KB.  
 
 ### Local Installation
 Git and [Python 3](https://www.python.org/downloads/windows/) are the only prerequisites for local development.  Once they have been installed...
 
-1. `git clone` your fork (using the Green "Code" btton) to create a local copy of the site.
+1. `git clone` your fork (using the Green "Code" button) to create a local copy of the site.
 2. Open the command prompt (Windows), navigate to the location you cloned the project to.
 3. Run command `pip install mkdocs-material mkdocs-glightbox mkdocs-video`. If you receive an error that Pip is not recognized, close and re-open the command prompt and try again
 4. Start a local development server by running the command `mkdocs serve`.  By default, this will build and run the website at `http://localhost:8000/` on your machine.
@@ -40,12 +40,12 @@ Will look like...
 ![Admonition Example](docs/img/admonition-example.jpg)
 
 ### Embedding Youtube Videos
-We have a special variant of an image to display an embeded Youtube video.  
+We have a special variant of an image to display an embedded Youtube video.  
 
 ```markdown
 ![type:video](https://www.youtube.com/embed/7mioa-hnndw)
 ```
-will show an embeded version of: https://www.youtube.com/watch?v=7mioa-hnndw
+will show an embedded version of: https://www.youtube.com/watch?v=7mioa-hnndw
 
 *Note that the `watch?v=` must be changed to `embed/` for this to work.*
 

--- a/custom-Fucntions.md
+++ b/custom-Fucntions.md
@@ -1,6 +1,6 @@
 # Customized Functions
 
-The mkdocs-macros plugin is an incredibly powerful part of our site.  It allowed Cyberlight to build several pices of custom functionality,  but has a few minor trade-offs we deal with as a result.  Both are outlined below.
+The mkdocs-macros plugin is an incredibly powerful part of our site.  It allowed Cyberlight to build several pieces of custom functionality,  but has a few minor trade-offs we deal with as a result.  Both are outlined below.
 
 ## Convenience methods
 
@@ -51,7 +51,7 @@ If present, overrides the general site description for this page of the KB.
 
 `repo`
 
-If prenset, links to the Github repository for the plugin referenced on this page. Displayed in the header when present.
+If present, links to the Github repository for the plugin referenced on this page. Displayed in the header when present.
 
 ![repo example]()
 

--- a/docs/faqs/battery/icue.md
+++ b/docs/faqs/battery/icue.md
@@ -15,7 +15,7 @@ Please follow these step-by-step instructions to allow the Stream Deck plugin to
 <ol>
 <li>Open iCue and Select your device from the top menu bar.</li>
 <li>On the left hand side, click Device Settings</li>
-<li>Select Enable Battery Guage in Notification Area</li>
+<li>Select Enable Battery Gauge in Notification Area</li>
 </ol>
 
 </details>
@@ -25,7 +25,7 @@ Please follow these step-by-step instructions to allow the Stream Deck plugin to
   <ol>
     <li>Open iCue and Select your device from the top menu bar</li>
     <li>On the left hand side, click <b>Device Settings</b></li>
-    <li>Select Enable Battery Guage in Notification Area
+    <li>Select Enable Battery Gauge in Notification Area
     <img src="../img/icue3-s3.png" alt="Step 3"></li>
     <li>Open iCue and Select Settings from the top menu bar</li>
     <li>Choose the device you want to see the battery stats for (and verify it shows the battery status right under the device’s image)</li>

--- a/docs/faqs/general/helping.md
+++ b/docs/faqs/general/helping.md
@@ -7,7 +7,7 @@ There are several ways you can help us out!
 <!---- Helping with our Open-Source projects found in [BarRaiders Github](https://github.com/BarRaider)
     - Developers who can port plugins over to Mac is needed --->
 
-## Writing help artices or making YouTube guides
+## Writing help articles or making YouTube guides
 We try to provide the best documentation and guides for our plugin users. Therefore having people help us with writing guides or making videos about the plugins they have a deeper knowledge about is very helpful.
 
 If you are interested in adding help articles or have made a YouTube video that you think we might have use for, contact us on our [Discord server](https://www.discord.barraider.com).

--- a/docs/faqs/supermacro/advanced-settings.md
+++ b/docs/faqs/supermacro/advanced-settings.md
@@ -5,7 +5,7 @@ Here you will find a detailed explanation of what each of the advanced settings 
 ​
 ## Settings
 ### Secondary ENTER behavior
-By default, when SuperMacro notices a new line, it simulates a  newline keystoke. When this is enabled SuperMacro will instead simulate a KEYPRESS event for the Enter/Return virtual keycode. In some apps, this may work better when dealing with new lines.
+By default, when SuperMacro notices a new line, it simulates a  newline keystroke. When this is enabled SuperMacro will instead simulate a KEYPRESS event for the Enter/Return virtual keycode. In some apps, this may work better when dealing with new lines.
 
 ### Forced Macro Mode
 Sends normal text (such as 'abc') as keystrokes (i.e. `{{a}}{{b}}{{c}}`).

--- a/docs/faqs/supermacro/commands.md
+++ b/docs/faqs/supermacro/commands.md
@@ -118,7 +118,7 @@
     | Mouse Move based on multi-screen resolutions|{{ "{{MOUSEXY:X,Y}} "}} (Move the cursor to the X,Y position on the screen. 0,0 is the [top-left] of your primary monitor. Supports both positive and negative values. Use along with the `Mouse Location` action to easily find the right coordinates on your PC<br>Supports variables too: {{ "{{MOUSEXY:$Var1,$Var2}} "}}|
     | Store current mouse position|{{ "{{MSAVEPOS}} "}} stores the current mouse cursor position.<br>The position is stored in variables: $MOUSE_X and $MOUSE_Y|
     | Move mouse to previous stored position|{{ "{{MLOADPOS}} "}} moves the mouse to the previous set position (when `{MSAVEPOS}` was called).|
-    | (DEPRICATED) Mouse Move based on ABSOLUTE position (DEPRICATED)|{{ "{{MOUSEPOS:X,Y}} "}} (Move the cursor to the X,Y position on the screen. Values from 0,0 [top-left] to 65535,65535 [bottom-right])|
+    | (DEPRECATED) Mouse Move based on ABSOLUTE position (DEPRECATED)|{{ "{{MOUSEPOS:X,Y}} "}} (Move the cursor to the X,Y position on the screen. Values from 0,0 [top-left] to 65535,65535 [bottom-right])|
 
 === "Windows Commands"
 
@@ -143,7 +143,7 @@
     |Action|Macro Command|
     |----|----|
     |{{ "{{//}} "}}|Comments Support: Anything after the {{ "{{//}} "}} sign will be ignored until end of line.<br>**Note:** The "Don't treat "New Line" as Enter" setting must be DISABLED for this to work properly|
-    |PAUSE|{{ "{{PAUSE:XXXX}} "}} (XXXX = length in miliseconds). Will pause execution of the rest of the SuperMacro for the time specified|
+    |PAUSE|{{ "{{PAUSE:XXXX}} "}} (XXXX = length in milliseconds). Will pause execution of the rest of the SuperMacro for the time specified|
     |KeyDown|{{ "{{KeyDown:XXXX}} "}} (XXXX = name of key| example {{ "{{KeyDown:F1}} "}}). Simulates holding the key down on the keyboard.<br>**Note:** Should be eventually accompanied by a `KeyUp` command|
     |KeyUp|{{ "{{KeyUp:XXXX}} "}} (XXXX = name of key| example {{ "{{KeyUp:SHIFT}} "}})|
     |MSavePos|{{ "{{MSAVEPOS}} "}} stores the current mouse cursor position.<br>The position is stored in variables: $MOUSE_X and $MOUSE_Y|

--- a/docs/faqs/supermacro/examples.md
+++ b/docs/faqs/supermacro/examples.md
@@ -92,7 +92,7 @@
 </details>
 
 <details>
-  <summary>Repalce all "l"'s with "Z"'s in the string `Hello World` and show it on key</summary>
+  <summary>Replace all "l"'s with "Z"'s in the string `Hello World` and show it on key</summary>
     ```
     {{ "{{VARSET:XX:Hello World}}" }}
     {{ "{{VARSET:A:l}}" }}
@@ -141,7 +141,7 @@
 </details>
 
 <details>
-  <summary>Get input from user, then load a file with the inputed name (from the `c:\temp` folder) to CLIPBOARD and show it on the Stream Deck Key. (Contributed by Bowser#2891)</summary>
+  <summary>Get input from user, then load a file with the inputted name (from the `c:\temp` folder) to CLIPBOARD and show it on the Stream Deck Key. (Contributed by Bowser#2891)</summary>
     <br>
   Note: Entire content of file may not fit within the screen of the Stream Deck Key.<br>
     ```

--- a/docs/faqs/supermacro/variables.md
+++ b/docs/faqs/supermacro/variables.md
@@ -5,7 +5,7 @@
 
 # Variables
 
-Variables are used to store data to be used further down in the Macro or in a different macro altogether. This opens up a whole world of options. You can read data from files, manipulate it, and then write it to either another file, to the Stream Deck key or execute it as a set of keystokes. Variables start with a `$` sign to differentiate them from normal text
+Variables are used to store data to be used further down in the Macro or in a different macro altogether. This opens up a whole world of options. You can read data from files, manipulate it, and then write it to either another file, to the Stream Deck key or execute it as a set of keystrokes. Variables start with a `$` sign to differentiate them from normal text
 
 ## Predefined Variables
 The following list of variables are always be available for you to use either with Functions (like CONCAT) or to execute as keyboard commands:

--- a/docs/faqs/voicemeeter/actions.md
+++ b/docs/faqs/voicemeeter/actions.md
@@ -4,7 +4,7 @@ tags:
     - streamdeck
     - barraider
     - voicemeeter
-description: "Explaination of all the available actions in the VoiceMeeter plugin by BarRaider for the Elgato Stream Deck."
+description: "Explanation of all the available actions in the VoiceMeeter plugin by BarRaider for the Elgato Stream Deck."
 ---
 
 # Available Actions
@@ -29,7 +29,7 @@ description: "Explaination of all the available actions in the VoiceMeeter plugi
 
 !!! info "Advanced users"
 
-    **Note:** This is for advanced users, but you can find field explainations under the avaliable fields page.
+    **Note:** This is for advanced users, but you can find field explanations under the available fields page.
 
 - Allows you to directly modify a whole set of settings
     - Example: `Strip[0].mono=1;Strip[1].Mute=1;Bus[2].Gain=-20;`
@@ -38,7 +38,7 @@ description: "Explaination of all the available actions in the VoiceMeeter plugi
 - Live feedback on whatever setting you choose
 - Option to turn off the Live feedback and set the title to whatever you want (including a prefix using the TitlePrefix parameter)
 
-## VoiceMeeter Advanced Toogle
+## VoiceMeeter Advanced Toggle
 Note: This is for advanced users but there are explanations under the Fields explained section below
 
 - Focused on toggling between two modes (versus press and long press in the VoiceMeeter Advanced Press/Long-Press)

--- a/docs/faqs/voicemeeter/fields.md
+++ b/docs/faqs/voicemeeter/fields.md
@@ -1,4 +1,4 @@
-# Fields explaination
+# Fields explanation
 - **Mode1 Key Press** - The configuration to set when we're toggling into Mode1 -> Use this to turn ON the setting e.g. `Strip[0].Mute=1`
 - **Mode1 Check** - True/False value to determine if we're in Mode1. 
     - Example: If you input: `Strip[0].Mute` the plugin will determine you're in Mode1 every time Strip0 is muted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ nav:
     - 'SuperMacro':
       #- 'Getting started': 'faqs/supermacro/getting-started.md' BLANK PAGE
       - 'Advanced Settings explained': 'faqs/supermacro/advanced-settings.md'
-      - 'Avaliable Actions': 'faqs/supermacro/actions.md'
+      - 'Available Actions': 'faqs/supermacro/actions.md'
       - 'Usage Examples': 'faqs/supermacro/examples.md'
       - 'Commands': 'faqs/supermacro/commands.md'
       - 'Functions': 'faqs/supermacro/functions.md'
@@ -30,7 +30,7 @@ nav:
       - 'Variables': 'faqs/supermacro/variables.md'
     - 'Twitch Tools':
       - 'Troubleshooting': 'faqs/twitch-tools/troubleshooting.md'
-      - 'Usage Examples': 'faqs/twitch-tools/examples.md'
+      #- 'Usage Examples': 'faqs/twitch-tools/examples.md' BLANK PAGE
     - 'VoiceMeeter':
       - 'Getting Started': 'faqs/voicemeeter/getting-started.md'
       - 'Available Actions': 'faqs/voicemeeter/actions.md'


### PR DESCRIPTION
"Usage Examples" under the Twitch Tools section is blank so I commented it out similar to https://github.com/BarRaiders/barraiders.github.io/blob/main/mkdocs.yml#L23 instead of removing it completely