### PR TITLE
Fix Favicon with the Marterial Theme

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -24,6 +24,7 @@ plugins:
   - mkdocs-video
 theme:
   name: "material"
+  favicon: "img/favicon.ico"
   custom_dir: overrides
   logo: "img/barraider-logo2.png"
   features:


### PR DESCRIPTION
Material Theme overrides the favicon (and other logos) so we have to override that.